### PR TITLE
Use nsls2forge docker image and reformat the recipe

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_:
         CONFIG: linux_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: nsls2/nsls2forge:latest
     maxParallel: 8
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -3,4 +3,4 @@ channel_sources:
 channel_targets:
 - nsls2forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- nsls2/nsls2forge:latest

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 About xpdsim
 ============
 
-Home: http://xpdacq.github.io/xpdSim/
+Home: http://xpdacq.github.io
 
-Package license: 
+Package license: BSD-3-Clause
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,9 @@ channel_sources:
   - nsls2forge,defaults
 channel_targets:
   - nsls2forge main
+docker_image:
+  - nsls2/nsls2forge:latest
+cuda_compiler_version:
+  - None
+python:
+  - 3.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
+{% set name = "xpdSim" %}
 {% set version = "0.4.0" %}
 {% set sha256 = "6b69e8d478a09e503c67f7235c77bef3c0ed3481dadb7dda0ad24c33599a5f1a" %}
 
 package:
-  name: xpdsim
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/xpdAcq/xpdSim/releases/download/{{ version }}/xpdSim-{{ version }}.tar.gz
+  url: https://github.com/xpdAcq/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -20,16 +21,19 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - ophyd=1.3.3
-    - pyfai
-    - databroker=0.13.0
     - bluesky
+    - databroker
+    - ophyd
+    - pyfai
 
 test:
   imports:
     - xpdsim
 
 about:
-  home: http://xpdacq.github.io/xpdSim/
+  home: http://xpdacq.github.io
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: Simulator objects for bluesky and ophyd
+  dev_url: https://github.com/xpdAcq/xpdSim
+  doc_url: http://xpdacq.github.io/xpdSim


### PR DESCRIPTION
This is to fix a hard pin to databroker 0.13, which is not compatible with the latest `collection` metapackage.